### PR TITLE
Equinox refactor

### DIFF
--- a/cvrnn_layer.py
+++ b/cvrnn_layer.py
@@ -1,0 +1,106 @@
+import equinox as eqx
+import jax, jax.numpy as jnp
+from typing import Optional, Tuple
+
+class CVRNNLayer(eqx.Module):
+    """
+    One cv-RNN layer:
+      - B:      (N×N) complex connectivity matrix
+      - nt:     number of timesteps to unroll
+      - x0:     optional fixed initial condition
+    """
+    B: jnp.ndarray
+    nt: int
+    x0: Optional[jnp.ndarray]
+
+    def __init__(self,
+                 B: jnp.ndarray,
+                 nt: int,
+                 x0: Optional[jnp.ndarray] = None,
+                 key: Optional[jax.Array] = None):
+        """
+        Initialize a CV-RNN layer.
+        
+        Parameters
+        ----------
+        B : complex connectivity matrix, shape (N, N)
+        nt : number of timesteps to unroll
+        x0 : optional pre-defined initial state, shape (N,)
+        key : optional random key for generating x0 if not provided
+        """
+        # B should already be complex128 of shape (N, N)
+        self.B = B
+        self.nt = nt
+        
+        # Initialize x0 if provided, otherwise keep as None
+        if x0 is not None:
+            self.x0 = x0
+        elif key is not None:
+            # Generate x0 from key
+            N = B.shape[0]
+            rand_angles = jax.random.uniform(
+                key, shape=(N,), minval=-jnp.pi, maxval=jnp.pi
+            )
+            self.x0 = jnp.exp(1j * rand_angles)
+        else:
+            self.x0 = None
+
+    def _generate_x0(self, key: jax.Array) -> jnp.ndarray:
+        """Generate random initial condition from a key."""
+        N = self.B.shape[0]
+        rand_angles = jax.random.uniform(
+            key, shape=(N,), minval=-jnp.pi, maxval=jnp.pi
+        )
+        return jnp.exp(1j * rand_angles)
+
+    def __call__(self,
+                 omega: jnp.ndarray,     # shape (..., N), float64
+                 x0: Optional[jnp.ndarray] = None,  # shape (..., N), complex128
+                 key: Optional[jax.Array] = None    # optional key for runtime initialization
+                 ) -> jnp.ndarray:
+        """
+        Runs the recurrent dynamics for nt steps.
+
+        Parameters
+        ----------
+        omega : frequencies for each node, shape (..., N)
+        x0 : optional initial state, shape (..., N). If None, uses the internally stored x0.
+        key : optional random key to generate x0 at runtime (highest priority)
+        
+        Returns
+        -------
+        x_history : complex128 array, shape (nt, ..., N)
+        
+        Notes
+        -----
+        Priority for determining initial state:
+        1. If key is provided, generate new x0 at runtime
+        2. If x0 is provided directly to __call__, use that 
+        3. If self.x0 exists (set during init), use that
+        4. Otherwise, raise ValueError
+        """
+        # Determine the initial state to use, with priority order
+        if key is not None:
+            # Generate new x0 at runtime (highest priority)
+            initial_x = self._generate_x0(key)
+        elif x0 is not None:
+            # Use explicitly provided x0
+            initial_x = x0
+        elif self.x0 is not None:
+            # Use the stored x0 from initialization
+            initial_x = self.x0
+        else:
+            # No initial state available
+            raise ValueError("No initial state (x0) provided. Either pass x0 or key to __call__, or initialize the layer with x0 or key.")
+
+        def step(x, _):
+            # x: shape (..., N)
+            # the core update: x ← (i·ω)*x + B @ x
+            x_next = (1j * omega) * x + jnp.matmul(self.B, x[..., None])[..., 0]
+            return x_next, x_next
+
+        # lax.scan will broadcast over any leading batch dims in initial_x/omega
+        _, hist = jax.lax.scan(step, initial_x, None, length=self.nt - 1)
+
+        # prepend the initial state
+        return jnp.concatenate([initial_x[None, ...], hist], axis=0)

--- a/example_2shapes.py
+++ b/example_2shapes.py
@@ -38,7 +38,6 @@ def main(seed, visualize_dynamics=False):
     N = Nr * Nc
     # ground‑truth labels available in data['labels'] if you want to compute accuracy
 
-
     # --- Plot the input image ---
     plt.figure()
     plt.imshow(im, cmap='gray')

--- a/example_natural_image.py
+++ b/example_natural_image.py
@@ -12,7 +12,8 @@ from sklearn.cluster import KMeans
 import argparse
 import os
 
-from cv_rnn import run_2layer, spatiotemporal_segmentation, plot_dynamics
+from cv_rnn import spatiotemporal_segmentation, plot_dynamics, gaussian_sheet
+from cvrnn_layer import CVRNNLayer, MultiLayerCVRNN
 
 def main(seed, visualize_dynamics=False):
     # Set matplotlib backend based on whether we're visualizing dynamics
@@ -28,7 +29,7 @@ def main(seed, visualize_dynamics=False):
     # --- hyperparameters ---
     alpha = (0.5, 0.5)
     sigma = (0.9, 0.0313)
-    layer_time_points = (60, 200)
+    nt1, nt2 = (60, 200)
     dims = [0, 1, 2]
     window_size = 40
     window_step = 40
@@ -38,13 +39,15 @@ def main(seed, visualize_dynamics=False):
     # Original image and preprocessed input image
     original_image = data['in']  # Original image
     im = data['im']              # Preprocessed input for cv-RNN
+    Nr, Nc = im.shape
+    N = Nr * Nc
 
     # --- Plot the original image ---
     plt.figure()
     plt.imshow(original_image, cmap='gray')
     plt.title('original image')
     plt.axis('off')
-    plt.savefig(os.path.join(output_dir, f'example_natural_image_original_seed_{seed}.png'), bbox_inches='tight')
+    plt.savefig(f'{output_dir}/example_natural_image_original_seed_{seed}.png', bbox_inches='tight')
     plt.close()
 
     # --- Plot the input image ---
@@ -52,33 +55,56 @@ def main(seed, visualize_dynamics=False):
     plt.imshow(im, cmap='gray')
     plt.title('input')
     plt.axis('off')
-    plt.savefig(os.path.join(output_dir, f'example_natural_image_input_seed_{seed}.png'), bbox_inches='tight')
+    plt.savefig(f'{output_dir}/example_natural_image_input_seed_{seed}.png', bbox_inches='tight')
     plt.close()
 
-    # --- run cv-RNN ---
-    nt = layer_time_points
-    X, mask = run_2layer(im, alpha, sigma, nt, seed=seed)
+    # build ω
+    omega = im.flatten().astype(jnp.float64)
 
-    # reshape and extract phase
-    Nr, Nc = im.shape
+    # build B1, B2
+    B1 = gaussian_sheet(Nr, Nc, alpha[0], sigma[0]).astype(jnp.complex128)
+    B2 = gaussian_sheet(Nr, Nc, alpha[1], sigma[1]).astype(jnp.complex128)
+
+    # instantiate layers & model
+    layer1 = CVRNNLayer(B=B1, nt=nt1)
+    layer2 = CVRNNLayer(B=B2, nt=nt2 - nt1)
+    model  = MultiLayerCVRNN([layer1, layer2])
+
+    # generate x0 using the same split pattern as run_2layer
+    key = jax.random.PRNGKey(seed)
+    key, subkey = jax.random.split(key)
+
+    # run multi-layer
+    (h1, h2), (mask1, mask2) = model(omega=omega, key=subkey)
+
+    # assemble full history and re-apply NaNs on masked nodes in layer 2
+    combined = jnp.concatenate([h1, h2], axis=0)  # (nt2, N)
+    nan_c = jnp.array(0+0j).at[()].set(complex(jnp.nan, jnp.nan))
+    times = jnp.arange(nt2)
+    tmask = times >= nt1              # shape (nt2,)
+    mask_time = jnp.outer(tmask, mask1)  # (nt2, N)
+    combined = jnp.where(mask_time, nan_c, combined)
+
+    # transpose, angle, reshape
+    X = combined.T                     # (N, nt2)
     x_full = jnp.angle(X).reshape(Nr, Nc, -1)
 
-    # visualize dynamics if requested
+    # optional dynamics plot
     if visualize_dynamics:
-        plot_dynamics(x_full, layer_time_points[0])
+        plot_dynamics(x_full, nt1)
 
     # --- spectral clustering ---
     # lift back onto complex unit circle
     x_flat = x_full.reshape(-1, x_full.shape[2])
     x_lift = jnp.exp(1j * x_flat)
-    valid_indices = jnp.where(~mask.flatten())[0]
-    x_valid = x_lift[valid_indices, :]
+    valid = ~mask1
+    x_valid = x_lift[valid, :]
 
     rho, V, D, prj = spatiotemporal_segmentation(
-        x_valid, dims, layer_time_points, window_size, window_step
+        x_valid, dims, (nt1, nt2), window_size, window_step
     )
 
-    # --- similarity projection ---
+    # --- similarity projection (last window) ---
     w = prj.shape[-1] - 1
     colors = jnp.angle(x_valid[:, 120])  # e.g. 120th timestep
     prj_last = prj[:, :, w]
@@ -86,34 +112,35 @@ def main(seed, visualize_dynamics=False):
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
     sc = ax.scatter(
-        np.array(prj_last[:, 0]),
-        np.array(prj_last[:, 1]),
-        np.array(prj_last[:, 2]),
+        np.array(prj_last[:,0]),
+        np.array(prj_last[:,1]),
+        np.array(prj_last[:,2]),
         c=np.array(colors), cmap='hsv', s=50)
-    ax.set_xlabel('dimension 1')
-    ax.set_ylabel('dimension 2')
-    ax.set_zlabel('dimension 3')
+    ax.set_xlabel('dim1')
+    ax.set_ylabel('dim2')
+    ax.set_zlabel('dim3')
     plt.title('similarity projection')
     fig.colorbar(sc, label='phase (rad)')
-    plt.savefig(os.path.join(output_dir, f'example_natural_image_similarity_seed_{seed}.png'), bbox_inches='tight')
+    plt.savefig(f'{output_dir}/example_natural_image_similarity_seed_{seed}.png', bbox_inches='tight')
     plt.close()
 
-    # --- final segmentation via k‑means (2 clusters) ---
-    predict = KMeans(n_clusters=2).fit_predict(np.array(prj_last[:, :3]))
+    # --- final k-means segmentation (2 clusters) ---
+    kmeans = KMeans(n_clusters=2, random_state=seed)
+    predict = kmeans.fit_predict(np.array(prj_last[:, :3]))
     
     # Build the segmented image.
     # Create an array of zeros for all pixels.
-    segmented_image = np.zeros(mask.flatten().shape, dtype=np.float32)
+    segmented = np.zeros(N, dtype=np.float32)
     # Assign the predicted cluster labels to these valid indices, adding one to make sure each cluster gets its own color
-    segmented_image[valid_indices] = predict+1
-    segmented_image = segmented_image.reshape(Nr, Nc)
+    segmented[np.where(valid)[0]] = predict + 1
+    segmented = segmented.reshape(Nr, Nc)
 
     plt.figure()
     # Here we "mask" the background (masked nodes remain 0) when displaying.
-    plt.imshow(segmented_image, cmap='viridis')
+    plt.imshow(segmented, cmap='viridis')
     plt.title('segmented image')
     plt.axis('off')
-    plt.savefig(os.path.join(output_dir, f'example_natural_image_segmented_seed_{seed}.png'), bbox_inches='tight')
+    plt.savefig(f'{output_dir}/example_natural_image_segmented_seed_{seed}.png', bbox_inches='tight')
     plt.close()
 
 if __name__ == "__main__":

--- a/test_cvrnn_layer.py
+++ b/test_cvrnn_layer.py
@@ -1,8 +1,8 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
-from cv_rnn import gaussian_sheet
-from cvrnn_layer import CVRNNLayer
+from cv_rnn import gaussian_sheet, run_2layer
+from cvrnn_layer import CVRNNLayer, MultiLayerCVRNN
 import unittest
 from scipy.io import loadmat
 
@@ -18,13 +18,10 @@ class TestCVRNNLayer(unittest.TestCase):
         a, s = 0.5, 0.9  # Connection parameters
         nt = 60          # Number of timesteps        
 
-        for dataset_name in dataset_names:
-            data = loadmat(f'dataset/{dataset_name}.mat')
+        for name in dataset_names:
+            data = loadmat(f'dataset/{name}.mat')
 
-            if dataset_name == "natural_image":
-                im = data["im"]
-            else:
-                im = data['images'][:, :, 0]   # get first image
+            im = data['im'] if name=='natural_image' else data['images'][:,:,0]
 
             # --- hyperparameters ---
             Nr, Nc = im.shape
@@ -73,32 +70,101 @@ class TestCVRNNLayer(unittest.TestCase):
                 x_history_original, 
                 x_history1, 
                 rtol=1e-10, atol=1e-10,
-                err_msg=f"Method 1: Explicit x0 in call doesn't match original implementation for {dataset_name} dataset"
+                err_msg=f"Method 1: Explicit x0 in call doesn't match original implementation for {name} dataset"
             )
             
             np.testing.assert_allclose(
                 x_history_original, 
                 x_history2, 
                 rtol=1e-10, atol=1e-10,
-                err_msg=f"Method 2: x0 set during initialization doesn't match original implementation for {dataset_name} dataset"
+                err_msg=f"Method 2: x0 set during initialization doesn't match original implementation for {name} dataset"
             )
             
             np.testing.assert_allclose(
                 x_history_original, 
                 x_history3, 
                 rtol=1e-10, atol=1e-10,
-                err_msg=f"Method 3: Using same initialization key doesn't match original implementation for {dataset_name} dataset"
+                err_msg=f"Method 3: Using same initialization key doesn't match original implementation for {name} dataset"
             )
             
             np.testing.assert_allclose(
                 x_history_original, 
                 x_history4, 
                 rtol=1e-10, atol=1e-10,
-                err_msg=f"Method 4: Using key at runtime in __call__ doesn't match original implementation for {dataset_name} dataset"
+                err_msg=f"Method 4: Using key at runtime in __call__ doesn't match original implementation for {name} dataset"
             )
             
-            print(f"✓ First CVRNNLayer produces identical results to the original implementation for {dataset_name} dataset")
-            
+            print(f"✓ First CVRNNLayer produces identical results to the original implementation for {name} dataset")
+
+    def test_multilayer_matches_run2layer(self):
+        """Validate that MultiLayerCVRNN reproduces run_2layer’s history & mask."""
+        # repeat over all three datasets
+        dataset_names = ['2shapes', '3shapes', 'natural_image']
+        a = (0.5, 0.5)
+        s = (0.9, 0.0313)
+        nt = (60, 200)
+        seed = 123
+
+        for name in dataset_names:
+            data = loadmat(f'dataset/{name}.mat')
+            im = data['im'] if name=='natural_image' else data['images'][:,:,0]
+            Nr, Nc = im.shape
+            N = Nr * Nc
+
+            # get the reference
+            X_old, mask_old = run_2layer(im, a, s, nt, seed)
+            # X_old shape (N, nt_total)
+            x_old = X_old.T          # shape (nt_total, N)
+            nt1, nt2 = nt
+
+            # rebuild exactly x0 & omega
+            key = jax.random.PRNGKey(seed)
+            key, sub = jax.random.split(key)
+            rand_angles = jax.random.uniform(sub, (N,), minval=-jnp.pi, maxval=jnp.pi)
+            x0 = jnp.exp(1j * rand_angles)
+            omega = im.flatten().astype(jnp.float64)
+
+            # build Equinox layers
+            B1 = gaussian_sheet(Nr, Nc, a[0], s[0]).astype(jnp.complex128)
+            B2 = gaussian_sheet(Nr, Nc, a[1], s[1]).astype(jnp.complex128)
+            layer1 = CVRNNLayer(B=B1, nt=nt1)
+            layer2 = CVRNNLayer(B=B2, nt=nt2-nt1)
+            model = MultiLayerCVRNN([layer1, layer2])
+
+            # run
+            (h1, h2), (mask1, _) = model(omega=omega, x0=x0)
+
+            # 1) First‐layer history matches x_old[:nt1]
+            np.testing.assert_allclose(
+                h1,
+                np.array(x_old[:nt1, :]),
+                rtol=1e-8, atol=1e-8,
+                err_msg=f"Layer1 history mismatch on {name}"
+            )
+
+            # 2) mask1 matches mask_old
+            np.testing.assert_array_equal(
+                np.array(mask1),
+                np.array(mask_old),
+                err_msg=f"Layer1 mask mismatch on {name}"
+            )
+
+            # 3) Second‐layer history matches x_old[nt1:] but only at valid nodes
+            valid = ~mask_old
+            # slice old
+            old2 = np.array(x_old[nt1:, :])      # shape (nt2-nt1, N)
+            new2 = np.array(h2)                  # same shape
+
+            # compare only valid columns
+            np.testing.assert_allclose(
+                new2[:, valid],
+                old2[:, valid],
+                rtol=1e-8, atol=1e-8,
+                err_msg=f"Layer2 history mismatch (valid nodes) on {name}"
+            )
+
+            print(f"✓ MultiLayerCVRNN matches run_2layer on {name}")
+
     def test_random_initialization(self):
         # Test initialization with a random key
         Nr, Nc = 5, 5

--- a/test_cvrnn_layer.py
+++ b/test_cvrnn_layer.py
@@ -1,0 +1,156 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+from cv_rnn import gaussian_sheet
+from cvrnn_layer import CVRNNLayer
+import unittest
+from scipy.io import loadmat
+
+class TestCVRNNLayer(unittest.TestCase):
+    
+    def test_cvrnn_layer_matches_original(self):
+        # Set the same random seed for reproducibility
+        seed = 42
+        key = jax.random.PRNGKey(seed)
+
+        dataset_names = ['2shapes', '3shapes', 'natural_image']
+
+        a, s = 0.5, 0.9  # Connection parameters
+        nt = 60          # Number of timesteps        
+
+        for dataset_name in dataset_names:
+            data = loadmat(f'dataset/{dataset_name}.mat')
+
+            if dataset_name == "natural_image":
+                im = data["im"]
+            else:
+                im = data['images'][:, :, 0]   # get first image
+
+            # --- hyperparameters ---
+            Nr, Nc = im.shape
+        
+            # Build the connection matrix (same as in run_2layer)
+            K1 = gaussian_sheet(Nr, Nc, a, s)
+            K1 = K1.astype(jnp.complex128)
+            
+            # Generate random initial condition
+            key, x0_key = jax.random.split(key)
+            rand_angles = jax.random.uniform(x0_key, shape=(Nr * Nc,), minval=-jnp.pi, maxval=jnp.pi)
+            x0 = jnp.exp(1j * rand_angles)
+            
+            # Generate random omega (frequencies)
+            key, omega_key = jax.random.split(key)
+            omega = jax.random.uniform(omega_key, shape=(Nr * Nc,), minval=0.0, maxval=1.0)
+            omega = omega.astype(jnp.float64)
+            
+            # Run the original implementation
+            def step_fn(carry, _):
+                x = carry
+                x = (1j * omega) * x + K1 @ x
+                return x, x
+
+            _, x_history_original = jax.lax.scan(step_fn, x0, None, length=nt-1)
+            x_history_original = jnp.concatenate((x0[None, :], x_history_original), axis=0)
+            
+            # Test 1: Pass x0 explicitly in the call
+            layer1 = CVRNNLayer(B=K1, nt=nt)
+            x_history1 = layer1(omega=omega, x0=x0)
+            
+            # Test 2: Initialize with x0 during construction
+            layer2 = CVRNNLayer(B=K1, nt=nt, x0=x0)
+            x_history2 = layer2(omega=omega)
+            
+            # Test 3: Initialize with the same random key that was used to generate x0
+            layer3 = CVRNNLayer(B=K1, nt=nt, key=x0_key)
+            x_history3 = layer3(omega=omega)
+            
+            # Test 4: Use the key at runtime in __call__
+            layer4 = CVRNNLayer(B=K1, nt=nt)  # Empty layer
+            x_history4 = layer4(omega=omega, key=x0_key)  # Generate x0 at runtime with same key
+            
+            # Compare all results with the original
+            np.testing.assert_allclose(
+                x_history_original, 
+                x_history1, 
+                rtol=1e-10, atol=1e-10,
+                err_msg=f"Method 1: Explicit x0 in call doesn't match original implementation for {dataset_name} dataset"
+            )
+            
+            np.testing.assert_allclose(
+                x_history_original, 
+                x_history2, 
+                rtol=1e-10, atol=1e-10,
+                err_msg=f"Method 2: x0 set during initialization doesn't match original implementation for {dataset_name} dataset"
+            )
+            
+            np.testing.assert_allclose(
+                x_history_original, 
+                x_history3, 
+                rtol=1e-10, atol=1e-10,
+                err_msg=f"Method 3: Using same initialization key doesn't match original implementation for {dataset_name} dataset"
+            )
+            
+            np.testing.assert_allclose(
+                x_history_original, 
+                x_history4, 
+                rtol=1e-10, atol=1e-10,
+                err_msg=f"Method 4: Using key at runtime in __call__ doesn't match original implementation for {dataset_name} dataset"
+            )
+            
+            print(f"✓ First CVRNNLayer produces identical results to the original implementation for {dataset_name} dataset")
+            
+    def test_random_initialization(self):
+        # Test initialization with a random key
+        Nr, Nc = 5, 5
+        a, s = 0.8, 0.2
+        nt = 10
+        
+        # Build the connection matrix
+        K = gaussian_sheet(Nr, Nc, a, s).astype(jnp.complex128)
+        
+        # Create omega
+        omega = jnp.ones((Nr * Nc,), dtype=jnp.float64) * 0.5
+        
+        # Initialize with a random key
+        key = jax.random.PRNGKey(123)
+        layer = CVRNNLayer(B=K, nt=nt, key=key)
+        
+        # Make sure we can run the layer with the internally generated x0
+        output = layer(omega=omega)
+        
+        # Verify shape is correct
+        self.assertEqual(output.shape[0], nt)
+        self.assertEqual(output.shape[1], Nr * Nc)
+        
+        # Verify complex dtype
+        self.assertEqual(output.dtype, jnp.complex128)
+        
+        # Test runtime dynamic initialization (key passed to __call__)
+        key1 = jax.random.PRNGKey(456)
+        key2 = jax.random.PRNGKey(789)
+        
+        # Same layer, different keys at runtime should give different results
+        output1 = layer(omega=omega, key=key1)
+        output2 = layer(omega=omega, key=key2)
+        
+        # Results should be different
+        are_equal = jnp.allclose(output1, output2, rtol=1e-10, atol=1e-10)
+        self.assertFalse(are_equal, "Using different keys at runtime should produce different results")
+        
+        # Same key at runtime should give same results
+        output3 = layer(omega=omega, key=key1)
+        output4 = layer(omega=omega, key=key1)
+        
+        # Results should be identical
+        np.testing.assert_allclose(
+            output3, 
+            output4, 
+            rtol=1e-10, atol=1e-10,
+            err_msg="Using the same key at runtime should produce identical results"
+        )
+        
+        print("✓ Random initialization tests passed")
+
+
+if __name__ == "__main__":
+    unittest.main() 


### PR DESCRIPTION
Adds new `CVRNNLayer` and `MultiLayerCVRNN` equinox modules for more composability/generality

- refactors existing examples scripts using the `MultiLayerCVRNN` equinox module
- adds random state argument to `KMeans` instantiation for reproducibility
- adds a unit test file that validates outputs are matched between old `run_2layer()` code and new forward pass of `MultiLayerCVRNN` module. Also includes unit test for hidden state sequences returned by a single layer in isolation
